### PR TITLE
Typo in Headers

### DIFF
--- a/src/main/main.go
+++ b/src/main/main.go
@@ -32,7 +32,7 @@ func (this *MyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
             contentType = "text/plain"
         }
 
-        w.Header().Add("Content Type", contentType)
+        w.Header().Add("Content-Type", contentType)
         w.Write(data)
     } else {
         w.WriteHeader(404)


### PR DESCRIPTION
Running this out of the box wasn't setting the Content-Type correctly for me in Chrome. Instead of setting "Content-Type," it was just adding a header "Content Type", which had no affect on how the file was processed. My stylesheets were coming in as text/plain. After adding the "-", the header was written correctly, and the browser was able to read my CSS.
